### PR TITLE
Alternative serial connexion for serial PMS5003

### DIFF
--- a/examples/pm25_simpletest.py
+++ b/examples/pm25_simpletest.py
@@ -16,13 +16,24 @@ reset_pin = None
 # reset_pin.value = False
 
 
-# If using with a computer such as Linux/RaspberryPi, Mac, Windows...
+# For use with a computer running Windows:
 # import serial
-#
 # uart = serial.Serial("COM30", baudrate=9600, timeout=1)
+
+# For use with microcontroller board:
+# (Connect the sensor TX pin to the board/computer RX pin)
+# uart = busio.UART(board.TX, board.RX, baudrate=9600)
+
+# For use with Raspberry Pi/Linux:
+# import serial
+# uart = serial.Serial("/dev/ttyS0", baudrate=9600, timeout=0.25)
+
+# For use with USB-to-serial cable:
+# import serial
+# uart = serial.Serial("/dev/ttyUSB0", baudrate=9600, timeout=0.25)
+
 # Connect to a PM2.5 sensor over UART
 # pm25 = adafruit_pm25.PM25_UART(uart, reset_pin)
-
 
 # Create library object, use 'slow' 100KHz frequency!
 i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)


### PR DESCRIPTION
This is based on the on the code from the learn guide for https://www.adafruit.com/product/3686 

The learn guide is here: https://learn.adafruit.com/pm25-air-quality-sensor/python-and-circuitpython

The code can be found here: https://github.com/adafruit/Adafruit_Learning_System_Guides/blob/693f8f250edef32fbd0ed44932bf9fca19277d17/PMS5003_Air_Quality_Sensor/PMS5003_CircuitPython/PMS5003_example.py