### PR TITLE
UART fixes

### DIFF
--- a/adafruit_pm25.py
+++ b/adafruit_pm25.py
@@ -170,17 +170,21 @@ class PM25_UART(PM25):
 
         self._uart = uart
         # Set PM2.5 to active mode via UART command
-        self._uart.write([0x42, 0x4d, 0xe1, 0x00, 0x01, 0x01, 0x71])
+        self._uart.write([0x42, 0x4D, 0xE1, 0x00, 0x01, 0x01, 0x71])
         # Check mode change response
         r = self._uart.read(8)
-        if (len(r) == 8) and (r[0] == 0x42) and (r[1] == 0x4d):
+        if (len(r) == 8) and (r[0] == 0x42) and (r[1] == 0x4D):
             if sum(r[0:6]) == struct.unpack(">H", r[6:8])[0]:
                 # print("UART active mode configured successfully")
                 time.sleep(0.1)
             else:
-                raise RuntimeError("Error configuring PM2.5 sensor for active reading, checksum failure on mode change response")
+                raise RuntimeError(
+                    "Error configuring PM2.5 sensor for active reading, checksum failure on mode change response"
+                )
         else:
-            raise RuntimeError("Error configuring PM2.5 sensor for active reading, malformed mode change response")
+            raise RuntimeError(
+                "Error configuring PM2.5 sensor for active reading, malformed mode change response"
+            )
         super().__init__()
 
     def _read_into_buffer(self):
@@ -198,6 +202,7 @@ class PM25_UART(PM25):
         for i in range(31):
             self._buffer[i + 1] = remain[i]
         # print([hex(i) for i in self._buffer])
+
 
 class PM25_UART_PASSIVE(PM25):
     """
@@ -222,33 +227,37 @@ class PM25_UART_PASSIVE(PM25):
 
         self._uart = uart
         # Set PM2.5 to passive mode via UART command
-        self._uart.write([0x42, 0x4d, 0xe1, 0x00, 0x00, 0x01, 0x70])
+        self._uart.write([0x42, 0x4D, 0xE1, 0x00, 0x00, 0x01, 0x70])
         # Check mode change response
         r = self._uart.read(8)
-        if (len(r) == 8) and (r[0] == 0x42) and (r[1] == 0x4d):
+        if (len(r) == 8) and (r[0] == 0x42) and (r[1] == 0x4D):
             if sum(r[0:6]) == struct.unpack(">H", r[6:8])[0]:
                 # print("UART passive mode configured successfully")
                 time.sleep(0.1)
             else:
-                raise RuntimeError("Error configuring PM2.5 sensor for active reading, checksum failure on mode change response")
+                raise RuntimeError(
+                    "Error configuring PM2.5 sensor for active reading, checksum failure on mode change response"
+                )
         else:
-            raise RuntimeError("Error configuring PM2.5 sensor for passive reading, malformed mode change response")
+            raise RuntimeError(
+                "Error configuring PM2.5 sensor for passive reading, malformed mode change response"
+            )
         time.sleep(0.2)
         super().__init__()
 
     def _read_into_buffer(self):
         self._uart.flushInput()
         # Request data from PM2.5 via UART command
-        self._uart.write([0x42, 0x4d, 0xe2, 0x00, 0x00, 0x01, 0x71])
+        self._uart.write([0x42, 0x4D, 0xE2, 0x00, 0x00, 0x01, 0x71])
         b = self._uart.read(32)
-        if (len(b) == 32) and (b[0] == 0x42) and (b[1] == 0x4d):
+        if (len(b) == 32) and (b[0] == 0x42) and (b[1] == 0x4D):
             self._buffer = b
-        elif len(b) <= 8: # Response to mode change or not ready after mode change, try again
+        elif len(b) <= 8:
             time.sleep(0.1)
             self._uart.flushInput()
-            self._uart.write([0x42, 0x4d, 0xe2, 0x00, 0x00, 0x01, 0x71])
+            self._uart.write([0x42, 0x4D, 0xE2, 0x00, 0x00, 0x01, 0x71])
             b = self._uart.read(32)
-            if (len(b) == 32) and (b[0] == 0x42) and (b[1] == 0x4d):
+            if (len(b) == 32) and (b[0] == 0x42) and (b[1] == 0x4D):
                 self._buffer(b)
             else:
                 raise RuntimeError("Unable to read from PM2.5 (incomplete frame)")

--- a/adafruit_pm25.py
+++ b/adafruit_pm25.py
@@ -149,8 +149,8 @@ class PM25_I2C(PM25):
         with self.i2c_device as i2c:
             try:
                 i2c.readinto(self._buffer)
-            except OSError:
-                raise RuntimeError("Unable to read from PM2.5 over I2C")
+            except OSError as err:
+                raise RuntimeError("Unable to read from PM2.5 over I2C") from err
 
 
 class PM25_UART(PM25):

--- a/adafruit_pm25.py
+++ b/adafruit_pm25.py
@@ -179,11 +179,13 @@ class PM25_UART(PM25):
                 time.sleep(0.1)
             else:
                 raise RuntimeError(
-                    "Error configuring PM2.5 sensor for active reading, checksum failure on mode change response"
+                    "Error configuring PM2.5 sensor for active reading, \
+                    checksum failure on mode change response"
                 )
         else:
             raise RuntimeError(
-                "Error configuring PM2.5 sensor for active reading, malformed mode change response"
+                "Error configuring PM2.5 sensor for active reading, \
+                malformed mode change response"
             )
         super().__init__()
 
@@ -236,11 +238,13 @@ class PM25_UART_PASSIVE(PM25):
                 time.sleep(0.1)
             else:
                 raise RuntimeError(
-                    "Error configuring PM2.5 sensor for active reading, checksum failure on mode change response"
+                    "Error configuring PM2.5 sensor for active reading, \
+                    checksum failure on mode change response"
                 )
         else:
             raise RuntimeError(
-                "Error configuring PM2.5 sensor for passive reading, malformed mode change response"
+                "Error configuring PM2.5 sensor for passive reading, \
+                malformed mode change response"
             )
         time.sleep(0.2)
         super().__init__()

--- a/examples/pm25_simpletest.py
+++ b/examples/pm25_simpletest.py
@@ -35,6 +35,15 @@ reset_pin = None
 # Connect to a PM2.5 sensor over UART
 # pm25 = adafruit_pm25.PM25_UART(uart, reset_pin)
 
+# Connect to a PM2.5 sensor over UART in passive mode on Enviro+ Hat on RPi
+# enable_pin = DigitalInOut(board.D27)
+# enable_pin.direction = Direction.OUTPUT
+# reset_pin = DigitalInOut(board.D22)
+# reset_pin.direction = Direction.OUTPUT
+# import serial
+# uart = serial.Serial("/dev/ttyAMA0", baudrate=9600, stopbits=1, parity="N", timeout=4)
+# pm25 = adafruit_pm25.PM25_UART_PASSIVE(uart, pin)
+
 # Create library object, use 'slow' 100KHz frequency!
 i2c = busio.I2C(board.SCL, board.SDA, frequency=100000)
 # Connect to a PM2.5 sensor over I2C


### PR DESCRIPTION
* Added code to set the PM2.5 device to "active" via UART commands in the `PM25_UART` init
* Added new `PM25_UART_PASSIVE` class with an init and `_read_into_buffer()`
* Added safety check and retry in PM25_UART_PASSIVE`'s `_read_into_buffer()` to retry in cases where the device wasn't ready after a mode change or the uart still had an 8-byte mode change response waiting
* Added `uart.read()` after mode change in each init to make sure that the change worked as expected and that the mode change bytes are removed from the buffer before any future reads
* Added comment block in example to illustrate usage of this new sub-class

Tested with a PM5003 on a RPi with an Enviro+ hat

Fixes issue #9 