### PR TITLE
UART Fixes and Featrues

### DIFF
--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -196,6 +196,8 @@ class PM25_UART(PM25):
         return cmd_frame
 
     def _read_uart(self):
+        # Disable too-many violations for this method, since it actually needs these branches
+        # pylint: disable=too-many-nested-blocks,too-many-branches
         """
         Reads a single frame via UART
 

--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -216,7 +216,7 @@ class PM25_UART(PM25):
                         serial_data.append(ord(second_byte))
                         frame_length_bytes = self._uart.read(2)
                         frame_length = int.from_bytes(frame_length_bytes, "big")
-                        if frame_length in range(0, (MAX_FRAME_SIZE - 4)):
+                        if 0 <= frame_length <= (MAX_FRAME_SIZE - 4):
                             serial_data.extend(frame_length_bytes)
                             data_frame = self._uart.read(frame_length)
                             if len(data_frame) > 0:

--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -171,6 +171,8 @@ class PM25_UART(PM25):
             time.sleep(0.01)
             self._reset_pin.value = True
             time.sleep(3)
+            if self._mode == "passive":
+                self.cmd_mode_passive()
 
     def pin_sleep(self):
         """

--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -68,7 +68,7 @@ class PM25_UART(PM25):
     A driver for the PM2.5 Air quality sensor over UART
     """
 
-    def __init__(self, uart, set_pin=None, reset_pin=None, mode="passive"):
+    def __init__(self, uart, reset_pin=None, set_pin=None, mode="passive"):
         self._uart = uart
         self._reset_pin = reset_pin
         self._set_pin = set_pin

--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -99,7 +99,7 @@ class PM25_UART(PM25):
             self._cmd_passive_read()
         self._buffer = self._read_uart()
 
-    def _cmd_mode_passive(self):
+    def cmd_mode_passive(self):
         """
         Sends command to device to enable 'passive' mode
 
@@ -112,7 +112,7 @@ class PM25_UART(PM25):
         time.sleep(1)
         return cmd_response
 
-    def _cmd_mode_active(self):
+    def cmd_mode_active(self):
         """
         Sends command to device to enable 'active' mode
 
@@ -131,7 +131,7 @@ class PM25_UART(PM25):
         time.sleep(1)
         return cmd_response
 
-    def _cmd_sleep(self):
+    def cmd_sleep(self):
         """
         Sends command to put device into low-power sleep mode via UART
         """
@@ -141,7 +141,7 @@ class PM25_UART(PM25):
         time.sleep(1)
         return cmd_response
 
-    def _cmd_wakeup(self):
+    def cmd_wakeup(self):
         """
         Sends command to wake device from low-power sleep mode via UART
 
@@ -153,14 +153,14 @@ class PM25_UART(PM25):
         self._uart.write(self._build_cmd_frame(PLANTOWER_CMD_WAKEUP))
         time.sleep(3)
 
-    def _cmd_passive_read(self):
+    def cmd_passive_read(self):
         """
         Sends command to request a data frame whlie in 'passive' mode and immediately reads in frame
         """
         self._uart.reset_input_buffer()
         self._uart.write(self._build_cmd_frame(PLANTOWER_CMD_READ))
 
-    def _pin_reset(self):
+    def pin_reset(self):
         """
         Resets device via RESET pin, but only if pin has been assigned
 
@@ -172,14 +172,14 @@ class PM25_UART(PM25):
             self._reset_pin.value = True
             time.sleep(3)
 
-    def _pin_sleep(self):
+    def pin_sleep(self):
         """
         Sleeps device via SET pin, but only if pin has been assigned
         """
         if self._set_pin is not None and self._set_pin.value:
             self._set_pin.value = False
 
-    def _pin_wakeup(self):
+    def pin_wakeup(self):
         """
         Wakes device via SET pin, but only if pin has been assigned
 

--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -38,7 +38,7 @@ Works with most (any?) Plantower UART interfaced PM2.5 sensor.
 Tested with:
 
 * PMS5003 on QT Py M0
-  * On power on, this device defaults to 'active' mode unless a mode reset command is received
+  * On power on, this device defaults to 'active' mode unless a mode change command is received
 
 **Software and Dependencies:**
 

--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -116,7 +116,13 @@ class PM25_UART(PM25):
         """
         Sends command to device to enable 'active' mode
 
-        In active mode, data frames are sent repeatedly every second
+        In active mode, data frames are sent repeatedly with an interval between 200 and 2300ms.
+
+        Timeframe between data frames will vary depending on the sensor's "sub-mode", which changes
+        in response to variations between reads.
+
+        Stable readings can extend timeframes up to 2300ms while rapid change may shorten timeframes
+        to a range as high as 800ms or as low as 200ms.
         """
         self._uart.reset_input_buffer()
         self._uart.write(self._build_cmd_frame(PLANTOWER_CMD_MODE_ACTIVE))

--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -78,7 +78,7 @@ class PM25_UART(PM25):
         if reset_pin:
             # Reset device on init, for good measure
             self._reset_pin.direction = Direction.OUTPUT
-            self._pin_reset()
+            self.pin_reset()
 
         if set_pin:
             # Pull set pin high to 'working' status (pulling low puts device to sleep)
@@ -86,9 +86,9 @@ class PM25_UART(PM25):
             self._set_pin.value = True
 
         if self._mode == "passive":
-            self._cmd_mode_passive()
+            self.cmd_mode_passive()
         elif self._mode == "active":
-            self._cmd_mode_active()
+            self.cmd_mode_active()
         else:
             raise RuntimeError("Invalid mode")
 
@@ -96,7 +96,7 @@ class PM25_UART(PM25):
 
     def _read_into_buffer(self):
         if self._mode == "passive":
-            self._cmd_passive_read()
+            self.cmd_passive_read()
         self._buffer = self._read_uart()
 
     def cmd_mode_passive(self):

--- a/adafruit_pm25/uart.py
+++ b/adafruit_pm25/uart.py
@@ -33,7 +33,12 @@ Implementation Notes
 
 **Hardware:**
 
-Works with most (any?) Plantower UART or I2C interfaced PM2.5 sensor.
+Works with most (any?) Plantower UART interfaced PM2.5 sensor.
+
+Tested with:
+
+* PMS5003 on QT Py M0
+  * On power on, this device defaults to 'active' mode unless a mode reset command is received
 
 **Software and Dependencies:**
 
@@ -46,38 +51,192 @@ import time
 from digitalio import Direction
 from . import PM25
 
+PLANTOWER_HEADER = b"\x42\x4D"
+
+PLANTOWER_CMD_MODE_PASSIVE = b"\xE1\x00\x00"
+PLANTOWER_CMD_MODE_ACTIVE = b"\xE1\x00\x01"
+PLANTOWER_CMD_READ = b"\xE2\x00\x00"
+PLANTOWER_CMD_SLEEP = b"\xE4\x00\x00"
+PLANTOWER_CMD_WAKEUP = b"\xE4\x00\x01"
+
+UART_RETRY_COUNT = 3
+MAX_FRAME_SIZE = 32
+
 
 class PM25_UART(PM25):
     """
     A driver for the PM2.5 Air quality sensor over UART
     """
 
-    def __init__(self, uart, reset_pin=None):
-        if reset_pin:
-            # Reset device
-            reset_pin.direction = Direction.OUTPUT
-            reset_pin.value = False
-            time.sleep(0.01)
-            reset_pin.value = True
-            # it takes at least a second to start up
-            time.sleep(1)
-
+    def __init__(self, uart, set_pin=None, reset_pin=None, mode="passive"):
         self._uart = uart
+        self._reset_pin = reset_pin
+        self._set_pin = set_pin
+        self._mode = mode
+
+        if reset_pin:
+            # Reset device on init, for good measure
+            self._reset_pin.direction = Direction.OUTPUT
+            self._pin_reset()
+
+        if set_pin:
+            # Pull set pin high to 'working' status (pulling low puts device to sleep)
+            self._set_pin.direction = Direction.OUTPUT
+            self._set_pin.value = True
+
+        if self._mode == "passive":
+            self._cmd_mode_passive()
+        elif self._mode == "active":
+            self._cmd_mode_active()
+        else:
+            raise RuntimeError("Invalid mode")
+
         super().__init__()
 
     def _read_into_buffer(self):
+        if self._mode == "passive":
+            read_buffer = self._cmd_passive_read()
+        self._buffer = self._read_uart()
+
+    def _cmd_mode_passive(self):
+        """
+        Sends command to device to enable 'passive' mode, where data frames are only sent after a read command
+        """
+        self._uart.reset_input_buffer()
+        self._uart.write(self._build_cmd_frame(PLANTOWER_CMD_MODE_PASSIVE))
+        cmd_response = self._read_uart()
+        self._mode = "passive"
+        time.sleep(1)
+        return cmd_response
+
+    def _cmd_mode_active(self):
+        """
+        Sends command to device to enable 'active' mode, where data frames are sent repeatedly every second
+        """
+        self._uart.reset_input_buffer()
+        self._uart.write(self._build_cmd_frame(PLANTOWER_CMD_MODE_ACTIVE))
+        cmd_response = self._read_uart()
+        self._mode = "active"
+        time.sleep(1)
+        return cmd_response
+
+    def _cmd_sleep(self):
+        """
+        Sends command to put device into low-power sleep mode via UART
+        """
+        self._uart.reset_input_buffer()
+        self._uart.write(self._build_cmd_frame(PLANTOWER_CMD_SLEEP))
+        cmd_response = self._read_uart()
+        time.sleep(1)
+        return cmd_response
+
+    def _cmd_wakeup(self):
+        """
+        Sends command to wake device from low-power sleep mode via UART
+
+        Wakeup from sleep via command requires about 3 seconds before the device becomes available
+
+        Additionally, this command does not trigger a response and behaves more like a reset or pin awake. On command reciept the device pulls TX low until about a second later as it initializes.
+        """
+        self._uart.reset_input_buffer()
+        self._uart.write(self._build_cmd_frame(PLANTOWER_CMD_WAKEUP))
+        time.sleep(3)
+
+    def _cmd_passive_read(self):
+        """
+        Sends command to request a data frame whlie in 'passive' mode and immediately reads in frame
+        """
+        self._uart.reset_input_buffer()
+        self._uart.write(self._build_cmd_frame(PLANTOWER_CMD_READ))
+
+    def _pin_reset(self):
+        """
+        Resets device via RESET pin, but only if pin has been assigned
+
+        Reset via pin requires about 3 seconds before the device becomes available
+        """
+        if self._reset_pin is not None:
+            self._reset_pin.value = False
+            time.sleep(0.01)
+            self._reset_pin.value = True
+            time.sleep(3)
+
+    def _pin_sleep(self):
+        """
+        Sleeps device via SET pin, but only if pin has been assigned
+        """
+        if self._set_pin is not None and self._set_pin.value == True:
+            self._set_pin.value = False
+
+    def _pin_wakeup(self):
+        """
+        Wakes device via SET pin, but only if pin has been assigned
+
+        Wakeup from sleep via pin takes about 3 seconds before device is available
+        """
+        if self._set_pin is not None and self._set_pin.value == False:
+            self._set_pin.value = True
+            time.sleep(3)
+
+    def _build_cmd_frame(self, cmd_bytes):
+        """
+        Builds a valid command frame byte array with checksum for given command bytes
+        """
+        if len(cmd_bytes) != 3:
+            raise RuntimeError("Malformed command frame")
+        cmd_frame = bytearray()
+        cmd_frame.extend(PLANTOWER_HEADER)
+        cmd_frame.extend(cmd_bytes)
+        cmd_frame.extend(sum(cmd_frame).to_bytes(2, "big"))
+        return cmd_frame
+
+    def _read_uart(self):
+        """
+        Reads a single frame via UART, ignoring bytes that are not frame headers to avoid reading in frames mid-stream
+        """
+        error_count = 0
+        first_bytes_tried = 0
         while True:
-            b = self._uart.read(1)
-            if not b:
-                raise RuntimeError("Unable to read from PM2.5 (no start of frame)")
-            if b[0] == 0x42:
-                break
-        self._buffer[0] = b[0]  # first byte and start of frame
+            serial_data = bytearray()
+            first_byte = self._uart.read(1)
+            if first_byte is not None:
+                if ord(first_byte) == PLANTOWER_HEADER[0]:
+                    serial_data.append(ord(first_byte))
+                    second_byte = self._uart.read(1)
+                    if ord(second_byte) == PLANTOWER_HEADER[1]:
+                        serial_data.append(ord(second_byte))
+                        frame_length_bytes = self._uart.read(2)
+                        frame_length = int.from_bytes(frame_length_bytes, "big")
+                        if frame_length > 0 and frame_length <= (MAX_FRAME_SIZE - 4):
+                            serial_data.extend(frame_length_bytes)
+                            data_frame = self._uart.read(frame_length)
+                            if len(data_frame) > 0:
+                                serial_data.extend(data_frame)
+                                frame_checksum = serial_data[-2:]
+                                checksum = sum(serial_data[:-2]).to_bytes(2, "big")
+                                if frame_checksum != checksum:
+                                    # Invalid checksum, ignore the frame, increment count, and try again
+                                    error_count += 1
+                                else:
+                                    return serial_data
+                            else:
+                                # Data frame empty, ignore the frame, increment error count, and try again
+                                error_count += 1
+                        else:
+                            # Invalid frame length, ignore the frame, increment error count, and try again
+                            error_count += 1
+                    else:
+                        # Invalid header low bit, ignore the frame, increment error count, and try again
+                        error_count += 1
+                else:
+                    # First bit isn't a header high bit, ignore and retry until we get a header bit
+                    first_bytes_tried += 1
+            else:
+                # If we didn't get a byte during our read, that's fine, just move on
+                pass
 
-        remain = self._uart.read(31)
-        if not remain or len(remain) != 31:
-            raise RuntimeError("Unable to read from PM2.5 (incomplete frame)")
-        self._buffer[1:] = remain
-
-
-#        print([hex(i) for i in self._buffer])
+            if error_count >= UART_RETRY_COUNT:
+                raise RuntimeError("Frame error count exceded retry threshold")
+            elif first_bytes_tried > MAX_FRAME_SIZE:
+                # If we haven't found a frame header in more than MAX_FRAME_SIZE bytes then increment error count and try again
+                error_count += 1


### PR DESCRIPTION
Rewrote `PM25_UART` class to add active/passive mode options (with passive mode default) as well as functions for controlling the PM25 device's mode and sleep status via both UART commands and pin toggles where possible.

UART class enhancements:

* Added functions for sending all of the supported UART commands I could find documentation for
  * Active/passive mode change via UART command
  * Data read request via UART command
  * Sleep/wake via UART command
* Added functions for handling both `SET` and `RESET` pins
  * Reset via pin
  * Sleep/wake via pin

UART read enhancements:

* If the device is in passive mode, it sends a "read" command prior to reading in a frame
  * In active mode it skips sending the command and simply reads in the next expected frame
* Handling for variable frame lengths using bytes 3/4 of the incoming frame
  * Allows for proper reading of command responses (which are 8 bytes)
* More resilient handling of cases reads may start mid-frame
* Error handling to avoid infinite loop scenarios
  * If we read in more than 32 bytes without seeing a header, we'll `RuntimeError`. If we get more than 3 malformed headers, invalid frame lengths, empty data frames, or failed checksums we'll also throw a `RuntimeError`

I've been testing this using a QT Py device while checking on the commands/responses and timeframes using a logic analyzer, which helped a lot with determining response, reset, and wakeup timeframes.